### PR TITLE
Handle CNV records with no nested sample element

### DIFF
--- a/src/convert.py
+++ b/src/convert.py
@@ -67,11 +67,13 @@ def extract_copy_numbers(results_payload_dict):
     if 'copy-number-alterations' in results_payload_dict['variant-report'].keys():
         if (results_payload_dict['variant-report']['copy-number-alterations'] is not None and
                 'copy-number-alteration' in results_payload_dict['variant-report']['copy-number-alterations'].keys()):
+
+            sample_id = results_payload_dict['variant-report'].get('samples', {}).get('sample', {}).get('@name')
             variants_dict = results_payload_dict['variant-report']['copy-number-alterations']['copy-number-alteration']
             copy_numbers = variants_dict if isinstance(variants_dict, list) else [variants_dict]
 
             for copy_number in copy_numbers:
-                copy_number_value = {'sample_id': copy_number['dna-evidence']['@sample'],
+                copy_number_value = {'sample_id': copy_number.get('dna-evidence', {}).get('@sample', sample_id),
                                      'gene': copy_number['@gene'],
                                      'copy_number': float(format(copy_number['@copy-number'])),
                                      'status': calculate_status(copy_number['@equivocal'], copy_number['@type']),

--- a/test/convert_tests.py
+++ b/test/convert_tests.py
@@ -81,7 +81,7 @@ foundation_source_dict = {
     'variant-report': {
         'samples': {
             'sample': {
-                '@name': 'sample1'
+                '@name': 'SA-1612348'
             }
         },
         'short-variants': {
@@ -161,10 +161,7 @@ foundation_source_dict = {
                     '@ratio': 2.69,
                     '@status': 'known',
                     '@type': 'partial amplification',
-                    '@number-of-exons': '13 of 13',
-                    'dna-evidence': {
-                        '@sample': 'SA-1612348'
-                    }
+                    '@number-of-exons': '13 of 13'
                 }
             ]
         },


### PR DESCRIPTION
I saw some tasks in production failed recently, where the copy number element did not have the nested sample element.  I updated the conversion to fallback to fetching the sample from the samples element if not found on the copy number element. 